### PR TITLE
Fix package names for rhel/centos using ads security

### DIFF
--- a/manifests/server/ads.pp
+++ b/manifests/server/ads.pp
@@ -31,7 +31,7 @@ class samba::server::ads($ensure = present,
   }
 
   if $osfamily == "RedHat" {
-    if $operatingsystemrelease =~ /^6\./) {
+    if $operatingsystemrelease =~ /^6\./ {
       $winbind_package = 'samba-winbind'
     } else {
       $winbind_package = 'samba-common'


### PR DESCRIPTION
RHEL/CentOS use krb5-workstation instead of krb5-user as well
as samba-winbind instead of winbind package names.
