### PR TITLE
Proper tcl quoting for password in expect

### DIFF
--- a/templates/configure_active_directory.erb
+++ b/templates/configure_active_directory.erb
@@ -125,10 +125,11 @@ for attempt in $(seq 1 $max_attempts); do
     echo "$attempt of $max_attempts:"
     ad_settle
     echo "Getting TGT for ${winbind_acct}@${my_realm}" >&2
-    $EXPECT -c spawn -noecho kinit -c $KRB5CCNAME '${winbind_acct}@${my_realm};
+    $EXPECT -c "spawn -noecho kinit -c $KRB5CCNAME ${winbind_acct}@${my_realm};
         expect :;
-        send ${password}\n;
-        expect eof'
+        send {${password}};
+        send \n;
+        expect eof"
     klist -c $KRB5CCNAME &> /dev/null && break
 done
 

--- a/templates/verify_active_directory.erb
+++ b/templates/verify_active_directory.erb
@@ -21,7 +21,7 @@ fi
 #  } >&2
 #fi
 
-password="<%= scope.lookupvar('samba::server::ads::winbind_pass') -%>"
+password='<%= scope.lookupvar('samba::server::ads::winbind_pass') -%>'
 
 # short hostname from facter
 my_hostname="<%= hostname -%>"
@@ -62,7 +62,8 @@ get_tgt() {
   (
   $EXPECT -c "spawn -noecho kinit -c $KRB5CCNAME ${winbind_acct}@${default_realm};
 	expect :;
-	send ${password}\n;
+	send {${password}};
+	send \n;
 	expect eof"
   ) &> /dev/null
   klist -c $KRB5CCNAME &> /dev/null


### PR DESCRIPTION
The former pull request did not deal with the verify script, the current one does and actually makes sure that tcl within expect doesn't interpret output from the ${password} command using { } around it.

See [5] Braces -  http://www.tcl.tk/man/tcl8.4/TclCmd/Tcl.htm#M9
