### PR TITLE
FIX: augeas runtime optimization (~4 sec per augeas resource)

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -8,10 +8,13 @@ class samba::server($interfaces = '',
   include samba::server::config
   include samba::server::service
 
-  $context = '/files/etc/samba/smb.conf'
-  $target = "target[. = 'global']"
+  $incl    = '/etc/samba/smb.conf'
+  $context = "/files/etc/samba/smb.conf"
+  $target  = "target[. = 'global']"
 
   augeas { 'global-section':
+    incl    => $incl,
+    lens    => 'Samba.lns',
     context => $context,
     changes => "set ${target} global",
     require => Class['samba::server::config'],
@@ -30,14 +33,18 @@ class samba::server($interfaces = '',
 }
 
 define set_samba_option ( $value = '', $signal = 'samba::server::service' ) {
+  $incl    = $samba::server::incl
   $context = $samba::server::context
-  $target = $samba::server::target
+  $target  = $samba::server::target
+
   $changes = $value ? {
     default => "set \"${target}/$name\" \"$value\"",
     ''      => "rm ${target}/$name",
   }
 
   augeas { "samba-$name":
+    incl    => $incl,
+    lens    => 'Samba.lns',
     context => $context,
     changes => $changes,
     require => Augeas['global-section'],

--- a/manifests/server/share.pp
+++ b/manifests/server/share.pp
@@ -16,11 +16,13 @@ define samba::server::share($ensure = present,
                             $public = '',
                             $writable = '',
                             $printable = '') {
-
+  $incl    = $samba::server::incl
   $context = $samba::server::context
-  $target = "target[. = '${name}']"
+  $target  = "target[. = '${name}']"
 
   augeas { "${name}-section":
+    incl    => $incl,
+    lens    => 'Samba.lns',
     context => $context,
     changes => $ensure ? {
       present => "set ${target} '${name}'",
@@ -31,179 +33,89 @@ define samba::server::share($ensure = present,
   }
 
   if $ensure == 'present' {
-    augeas { "${name}-browsable":
-      context => $context,
-      changes => $browsable ? {
-        true    => "set ${target}/browsable yes",
-        false   => "set ${target}/browsable no",
-        default => "rm ${target}/browsable",
+    $changes = [
+      $browsable ? {
+          true    => "set \"${target}/browsable\" yes",
+          false   => "set \"${target}/browsable\" no",
+          default => "rm  \"${target}/browsable\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-comment":
-      context => $context,
-      changes => $comment ? {
-        default => "set ${target}/comment '${comment}'",
-        ''      => "rm ${target}/comment",
+      $comment ? {
+          default => "set \"${target}/comment\" '${comment}'",
+          ''      => "rm  \"${target}/comment\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-copy":
-      context => $context,
-      changes => $copy ? {
-        default => "set ${target}/copy '${copy}'",
-        ''      => "rm ${target}/copy",
+      $copy ? {
+          default => "set \"${target}/copy\" '${copy}'",
+          ''      => "rm  \"${target}/copy\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-create_mask":
-      context => $context,
-      changes => $create_mask ? {
+      $create_mask ? {
         default => "set \"${target}/create mask\" '${create_mask}'",
-        ''      => "rm \"${target}/create mask\"",
+        ''      => "rm  \"${target}/create mask\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-directory_mask":
-      context => $context,
-      changes => $directory_mask ? {
+      $directory_mask ? {
         default => "set \"${target}/directory mask\" '${directory_mask}'",
-        ''      => "rm \"${target}/directory mask\"",
+        ''      => "rm  \"${target}/directory mask\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-force_create_mask":
-      context => $context,
-      changes => $force_create_mask ? {
+      $force_create_mask ? {
         default => "set \"${target}/force create mask\" '${force_create_mask}'",
-        ''      => "rm \"${target}/force create mask\"",
+        ''      => "rm  \"${target}/force create mask\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-force_directory_mask":
-      context => $context,
-      changes => $force_directory_mask ? {
+      $force_directory_mask ? {
         default => "set \"${target}/force directory mask\" '${force_directory_mask}'",
-        ''      => "rm \"${target}/force directory mask\"",
+        ''      => "rm  \"${target}/force directory mask\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-force_group":
-      context => $context,
-      changes => $force_group ? {
+      $force_group ? {
         default => "set \"${target}/force group\" '${force_group}'",
-        ''      => "rm \"${target}/force group\"",
+        ''      => "rm  \"${target}/force group\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-force_user":
-      context => $context,
-      changes => $force_user ? {
+      $force_user ? {
         default => "set \"${target}/force user\" '${force_user}'",
-        ''      => "rm \"${target}/force user\"",
+        ''      => "rm  \"${target}/force user\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-guest_account":
-      context => $context,
-      changes => $guest_account ? {
+      $guest_account ? {
         default => "set \"${target}/guest account\" '${guest_account}'",
-        ''      => "rm \"${target}/guest account\"",
+        ''      => "rm  \"${target}/guest account\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-guest_ok":
-      context => $context,
-      changes => $guest_ok ? {
+      $guest_ok ? {
         true    => "set \"${target}/guest ok\" yes",
         false   => "set \"${target}/guest ok\" no",
-        default => "rm \"${target}/guest ok\"",
+        default => "rm  \"${target}/guest ok\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-guest_only":
-      context => $context,
-      changes => $guest_only ? {
+      $guest_only ? {
         true    => "set \"${target}/guest only\" yes",
         false   => "set \"${target}/guest only\" no",
-        default => "rm \"${target}/guest only\"",
+        default => "rm  \"${target}/guest only\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-path":
-      context => $context,
-      changes => $path ? {
+      $path ? {
         default => "set ${target}/path '${path}'",
-        ''      => "rm ${target}/path",
+        ''      => "rm  ${target}/path",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-read_only":
-      context => $context,
-      changes => $read_only ? {
+      $read_only ? {
         true    => "set \"${target}/read only\" yes",
         false   => "set \"${target}/read only\" no",
-        default => "rm \"${target}/read_only\"",
+        default => "rm  \"${target}/read_only\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-public":
-      context => $context,
-      changes => $public ? {
+      $public ? {
         true    => "set \"${target}/public\" yes",
         false   => "set \"${target}/public\" no",
-        default => "rm \"${target}/public\"",
+        default => "rm  \"${target}/public\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-writable":
-      context => $context,
-      changes => $writable ? {
+      $writable ? {
         true    => "set \"${target}/writable\" yes",
         false   => "set \"${target}/writable\" no",
-        default => "rm \"${target}/writable\"",
+        default => "rm  \"${target}/writable\"",
       },
-      require => Augeas["${name}-section"],
-      notify  => Class['samba::server::service']
-    }
-
-    augeas { "${name}-printable":
-      context => $context,
-      changes => $printable ? {
+      $printable ? {
         true    => "set \"${target}/printable\" yes",
         false   => "set \"${target}/printable\" no",
-        default => "rm \"${target}/printable\"",
+        default => "rm  \"${target}/printable\"",
       },
+    ]
+
+    augeas { "${name}-changes":
+      incl    => $incl,
+      lens    => 'Samba.lns',
+      context => $context,
+      changes => $changes,
       require => Augeas["${name}-section"],
       notify  => Class['samba::server::service']
     }


### PR DESCRIPTION
Nice module, but running it to configure ~50 shares it took us about 360 sec to configure the shares and ~70 sec for an empty run (after all shares got configured).

The fix reduces the lens loaded and files the augeas resources are aplied to(/etc/samba/smb.conf).
Now the puppet run takes us ~60 sec to configure all the shares and ~30 sec for an empty run
