### PR TITLE
Remove notification for "Check winbind service"

### DIFF
--- a/manifests/server/winbind.pp
+++ b/manifests/server/winbind.pp
@@ -1,10 +1,6 @@
 class samba::server::winbind ($ensure = running, $enable = true) {
   $service_name = 'winbind'
 
-  notify { 'winbind-service':
-    message => 'Check winbind service',
-  }
-
   service { $service_name:
     ensure      => $ensure,
     hasstatus   => true,


### PR DESCRIPTION
I really like to keep log output very clean.. This seems unnecessary and it's sticking out like a sore thumb when doing "puppet agent -t"
