### PR TITLE
Update add_samba_user to check uid

### DIFF
--- a/templates/add_samba_user
+++ b/templates/add_samba_user
@@ -4,7 +4,15 @@
 # call as:
 # > add_samba_user "USERNAME" "PASSWORD"
 
-/bin/echo -e "$2\n$2\n" | sudo /usr/bin/pdbedit -a "$1" -t 1>/dev/null
+# check if we need sudo
+$UID=`id -u`
+if [ $UID = 0 ]; then
+	$PDBEDIT="/usr/bin/pdbedit"
+else
+	%PDBEDIT="sudo /usr/bin/pdbedit"
+fi
+
+/bin/echo -e "$2\n$2\n" | $PDBEDIT -a "$1" -t 1>/dev/null
 results=$?
 
 if [ $results = 0 ]; then


### PR DESCRIPTION
If uid=0 then sudo should not be used. This is useful when running inside limited environment using root privileges (E.G. inside docker)