### PR TITLE
Also start nmbd on ubuntu (and other systems that split out smbd and nmbd service configuration files)

### DIFF
--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -9,12 +9,14 @@ class samba::server::params {
     'Debian': {
       case $::operatingsystem{
         'Debian': { $service_name = 'samba' }
-        'Ubuntu': { $service_name = 'smbd' }
+        'Ubuntu': { $service_name = 'smbd'
+                    $nmbd_name = 'nmbd' }
         default: { $service_name = 'samba' }
       }
     }
     'Gentoo': { $service_name = 'samba' }
-    'Archlinux': { $service_name = 'smbd' }
+    'Archlinux': { $service_name = 'smbd'
+                   $nmbd_name = 'nmbd' }
 
     # Currently Gentoo has $::osfamily = "Linux". This should change in
     # Factor 1.7.0 <http://projects.puppetlabs.com/issues/17029>, so

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -12,4 +12,14 @@ class samba::server::service (
     enable      => $enable,
     require     => Class['samba::server::config']
   }
+
+  if $nmbd_name != undef {
+    service { $nmbd_name :
+      ensure     => $ensure,
+      hasrestart => false,
+      enable     => $enable,
+      require    => Class['samba::server::config'],
+    }
+  }
+
 }


### PR DESCRIPTION
On Ubuntu smbd and nmbd are split in init.d, so both need to be started. According to documentation Arch does the same. I am not sure if e.g. Redhat also requires this.
