### PR TITLE
Typo in init.pp stops variable comparison working

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,7 @@
 class samba {
   include samba::server
 
-  if samba::server::security == 'ads' {
+  if $::samba::server::security == 'ads' {
     include samba::server::ads
   }
 }


### PR DESCRIPTION
What was supposed to be a variable in the comparison isn't, so the test is never true.  Including the samba class never includes the samba::server::ads class as a result.
