### PR TITLE
Handle joining an OU with a space in the name

### DIFF
--- a/templates/configure_active_directory.erb
+++ b/templates/configure_active_directory.erb
@@ -112,7 +112,7 @@ if [ "$action" = "join" ]; then
     fi
 
     logger -st $PROG "Joining AD domain" >&2
-    $NET ads $action -U "${winbind_acct}%${password}" ${ou_parameter} \
+    $NET ads $action -U "${winbind_acct}%${password}" "${ou_parameter}" \
 	| grep Joined && success=true || success=false
 
 if [ $success = "false" ]; then


### PR DESCRIPTION
Previously attempting to join an OU with a space in the name would fail as the createcomputer= string wouldn't be passed to net ads join as a single parameter.