### PR TITLE
Add parameter to disable automatic join of domain

### DIFF
--- a/manifests/server/ads.pp
+++ b/manifests/server/ads.pp
@@ -21,7 +21,8 @@ class samba::server::ads($ensure = present,
   $map_system                 = 'no',
   $map_archive                = 'no',
   $map_readonly               = 'no',
-  $target_ou                  = 'Nix_Mashine') {
+  $target_ou                  = 'Nix_Mashine',
+  $perform_join               = true) {
 
   $krb5_user_package = $::osfamily ? {
     'RedHat' => 'krb5-workstation',
@@ -122,10 +123,12 @@ class samba::server::ads($ensure = present,
         'samba-winbind use default domain'], Service['winbind'] ],
   }
 
-  exec {'join-active-directory':
-    # join the domain configured in samba.conf
-    command => '/sbin/configure_active_directory -j',
-    unless  => '/sbin/verify_active_directory',
-    require => [ File['configure_active_directory', 'verify_active_directory'], Service['winbind'] ],
+  if ($perform_join) {
+    exec {'join-active-directory':
+      # join the domain configured in samba.conf
+      command => '/sbin/configure_active_directory -j',
+      unless  => '/sbin/verify_active_directory',
+      require => [ File['configure_active_directory', 'verify_active_directory'], Service['winbind'] ],
+    }
   }
 }

--- a/spec/classes/samba__server__ads_spec.rb
+++ b/spec/classes/samba__server__ads_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'samba::server::ads', :type => :class do
+  let( :facts ) { { :osfamily => 'Debian' } }
+  context "Default config" do
+    it { should contain_exec('join-active-directory') }
+  end
+
+  context "No join" do
+    let ( :params ) { { 'perform_join' => false }}
+    it { should_not contain_exec('join-active-directory') }
+  end
+
+  context "Join 'forced'" do
+    let ( :params ) { { 'perform_join' => true }}
+    it { should contain_exec('join-active-directory') }
+  end
+end
+

--- a/templates/configure_active_directory.erb
+++ b/templates/configure_active_directory.erb
@@ -57,7 +57,7 @@ done
 password='<%= scope.lookupvar('samba::server::ads::winbind_pass') -%>'
 
 # short hostname from facter
-my_hostname="<%= hostname -%>"
+my_hostname="<%= @hostname -%>"
 
 # what account do we use for net ads commands?
 winbind_acct="<%= scope.lookupvar('samba::server::ads::winbind_acct') -%>"

--- a/templates/verify_active_directory.erb
+++ b/templates/verify_active_directory.erb
@@ -24,7 +24,7 @@ fi
 password='<%= scope.lookupvar('samba::server::ads::winbind_pass') -%>'
 
 # short hostname from facter
-my_hostname="<%= hostname -%>"
+my_hostname="<%= @hostname -%>"
 
 winbind_acct="<%= scope.lookupvar('samba::server::ads::winbind_acct') -%>"
 


### PR DESCRIPTION
I do not like having a Admin-Password lying around on my machine; since I use this module for a machine that will seldom be reinstalled, it's OK if the join needs an ssh-login.