### PR TITLE
Define the NMD service name for Redhat/CentOS

### DIFF
--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -2,7 +2,10 @@
 #
 class samba::server::params {
   case $::osfamily {
-    'Redhat': { $service_name = 'smb' }
+    'Redhat': {
+      $service_name = 'smb'
+      $nmbd_name = 'nmb'
+    }
     'Debian': {
       case $::operatingsystem {
         'Debian': {


### PR DESCRIPTION
When using strict_variables the $nmbd_name variable name is not defined when using Redhat and thus fails compilation.