### PR TITLE
Fix dependencies between classes

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -4,6 +4,7 @@ class samba::server::service (
   $ensure = running,
   $enable = true
 ) inherits samba::server::params {
+  include ::samba::server::config
 
   service { $samba::server::params::service_name :
     ensure     => $ensure,

--- a/manifests/server/user.pp
+++ b/manifests/server/user.pp
@@ -5,6 +5,7 @@ define samba::server::user (
   $user_name = $name,
 ) {
   require ::samba::server::install
+  include ::samba::server::service
 
   exec { "add smb account for ${user_name}":
     command => "/bin/echo -e '${password}\\n${password}\\n' | /usr/bin/pdbedit --password-from-stdin -a '${user_name}'",


### PR DESCRIPTION
The user class was giving me this error:

```
Error: Could not find dependent Class[Samba::Server::Service] for Exec[add smb account for ...] at ...
```

After some digging I found a couple missing `include`s and have added those so that I can use the `user` Class. Give it a glance and merge if okay.

Improvements or better fixes are welcome.