### PR TITLE
make package name configurable

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -14,6 +14,7 @@ class samba::server($bind_interfaces_only = 'yes',
                     $netbios_name = '',
                     $obey_pam_restrictions = '',
                     $os_level = '',
+                    $package_name = 'samba',
                     $pam_password_change = '',
                     $panic_action = '',
                     $passdb_backend = '',
@@ -34,7 +35,9 @@ class samba::server($bind_interfaces_only = 'yes',
                     $workgroup = '',
                     $interfaces = '' ) {
 
-  include samba::server::install
+  class { '::samba::server::install':
+    package_name => $package_name,
+  }
   include samba::server::config
   include samba::server::service
 

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -1,7 +1,9 @@
 # == Class samba::server::install
 #
-class samba::server::install {
-  package { 'samba':
+class samba::server::install(
+  $package_name = 'samba'
+) {
+  package { $package_name:
     ensure => installed
   }
 }


### PR DESCRIPTION
For when Samba is provided by a third party and the package name is not "samba".