### PR TITLE
Remove `User` requirement from the samba user class:

### DIFF
--- a/manifests/server/user.pp
+++ b/manifests/server/user.pp
@@ -6,10 +6,11 @@ define samba::server::user (
 ) {
   require ::samba::server::install
 
+  User <| |> -> Samba::Server::User <| |>
+
   exec { "add smb account for ${user_name}":
     command => "/bin/echo -e '${password}\\n${password}\\n' | /usr/bin/pdbedit --password-from-stdin -a '${user_name}'",
     unless  => "/usr/bin/pdbedit '${user_name}'",
-    require => [ User[$user_name] ],
     notify  => Class['samba::server::service'] #TODO: Is this really required??
   }
 }


### PR DESCRIPTION
Instead of doing `require => User[..]` replace this with a collector so
that if users are not managed with puppet this class still works, for
example if they are in LDAP.