### PR TITLE
Refactoring check for definition samba::server::params::nmbd_name

### DIFF
--- a/manifests/server/ads.pp
+++ b/manifests/server/ads.pp
@@ -24,13 +24,13 @@ class samba::server::ads($ensure = present,
   $target_ou                  = 'Nix_Mashine',
   $perform_join               = true) {
 
-  $krb5_user_package = $::osfamily ? {
+  $krb5_user_package = $facts['os']['family'] ? {
     'RedHat' => 'krb5-workstation',
     default  => 'krb5-user',
   }
 
-  if $::osfamily == 'RedHat' {
-    if $::operatingsystemrelease =~ /^6\./ {
+  if $facts['os']['family'] == 'RedHat' {
+    if $facts['os']['release']['full'] =~ /^6\./ {
       $winbind_package = 'samba-winbind'
     } else {
       $winbind_package = 'samba-common'

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -1,12 +1,12 @@
 # == Class samba::server::params
 #
 class samba::server::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     'Redhat': { $service_name = 'smb' }
     'Debian': {
-      case $::operatingsystem {
+      case $facts['os']['name'] {
         'Debian': {
-          case $::operatingsystemmajrelease {
+          case $facts['os']['release']['major'] {
             '8' : { $service_name = 'smbd' }
             default: { $service_name = 'samba' }
           }
@@ -28,11 +28,11 @@ class samba::server::params {
     # Factor 1.7.0 <http://projects.puppetlabs.com/issues/17029>, so
     # adding workaround.
     'Linux': {
-      case $::operatingsystem {
+      case $facts['os']['name'] {
         'Gentoo':  { $service_name = 'samba' }
-        default: { fail("${::operatingsystem} is not supported by this module.") }
+        default: { fail("${facts['os']['name']} is not supported by this module.") }
       }
     }
-    default: { fail("${::osfamily} is not supported by this module.") }
+    default: { fail("${facts['os']['family']} is not supported by this module.") }
   }
 }

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -13,7 +13,7 @@ class samba::server::service (
     require    => Class['samba::server::config']
   }
 
-  if $samba::server::params::nmbd_name != undef {
+  if defined('$samba::server::params::nmbd_name') {
     service { $samba::server::params::nmbd_name :
       ensure     => $ensure,
       hasrestart => false,


### PR DESCRIPTION
This is a necessary change for the module to work with puppet 8.x.x